### PR TITLE
Add color theme selector with dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,11 @@
             font-family: Arial, sans-serif;
             margin: 20px;
             line-height: 1.6;
+            background-color: #fff;
+            color: #333;
         }
         h1, h2 {
-            color: #333;
+            color: inherit;
         }
         canvas {
             display: block;
@@ -69,6 +71,49 @@
         }
         .trend-container {
             overflow-x: auto;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            background-color: #f9f9f9;
+        }
+
+        /* Tema oscuro */
+        body.dark {
+            background-color: #121212;
+            color: #f0f0f0;
+        }
+        body.dark h1,
+        body.dark h2 {
+            color: #fff;
+        }
+        body.dark .summary {
+            background-color: #1e4620;
+            border-color: #388e3c;
+            color: #c8e6c9;
+        }
+        body.dark .highlight {
+            background-color: #333;
+            color: #f0f0f0;
+        }
+        body.dark .form-container {
+            background-color: #1f1f1f;
+            border-color: #555;
+        }
+        body.dark .trend-container {
+            background-color: #1f1f1f;
+            border-color: #555;
+        }
+        body.dark button {
+            background-color: #0d47a1;
+        }
+        body.dark button:hover {
+            background-color: #1565c0;
+        }
+        body.dark input,
+        body.dark select {
+            background-color: #333;
+            color: #f0f0f0;
+            border-color: #555;
         }
     </style>
 </head>
@@ -87,6 +132,14 @@
     <div class="highlight">
         Información correspondiente a los Turnos 1, 2 y 3 del SAR Arpillerista Elsa Romo Aravena.
     </div>
+
+    <!-- Selección de tema -->
+    <label>Modo de color:
+        <select id="selectorTema">
+            <option value="claro">Claro</option>
+            <option value="oscuro">Oscuro</option>
+        </select>
+    </label>
 
     <!-- Formulario para ingresar datos manualmente -->
     <div class="form-container">
@@ -121,17 +174,17 @@
     <!-- Gráficos Comparativos para Turnos 1, 2 y 3 -->
     <div id="graficoTurno1Container" class="grafico-turno">
         <h2>Gráfico Comparativo - Turno 1 (Por Día)</h2>
-        <canvas id="graficoTurno1Dias" width="400" height="200"></canvas>
+        <canvas id="graficoTurno1Dias" width="600" height="300"></canvas>
     </div>
 
     <div id="graficoTurno2Container" class="grafico-turno">
         <h2>Gráfico Comparativo - Turno 2 (Por Día)</h2>
-        <canvas id="graficoTurno2Dias" width="400" height="200"></canvas>
+        <canvas id="graficoTurno2Dias" width="600" height="300"></canvas>
     </div>
 
     <div id="graficoTurno3Container" class="grafico-turno">
         <h2>Gráfico Comparativo - Turno 3 (Por Día)</h2>
-        <canvas id="graficoTurno3Dias" width="400" height="200"></canvas>
+        <canvas id="graficoTurno3Dias" width="600" height="300"></canvas>
     </div>
 
     <!-- Gráfico de Consolidado por Establecimiento -->
@@ -140,20 +193,59 @@
 
     <!-- Gráfico de Tendencias -->
     <h2>Gráfico de Tendencias</h2>
+    <label>Ver:
+        <select id="seleccionTendencia">
+            <option value="todos">Todos los turnos</option>
+            <option value="1">Turno 1</option>
+            <option value="2">Turno 2</option>
+            <option value="3">Turno 3</option>
+        </select>
+    </label>
     <div class="trend-container">
-        <canvas id="graficoTendencias" width="600" height="200"></canvas>
+        <canvas id="graficoTendencias" width="600" height="300"></canvas>
     </div>
 
     <script>
+        const paletas = {
+            claro: {
+                ingresos: 'rgba(75, 192, 192, 0.6)',
+                altas: 'rgba(54, 162, 235, 0.6)',
+                traslados: 'rgba(255, 206, 86, 0.6)',
+                policial: 'rgba(153, 102, 255, 0.6)',
+                derivados: 'rgba(255, 99, 132, 0.6)',
+                borde1: 'rgba(54, 162, 235, 1)',
+                borde1Trans: 'rgba(54, 162, 235, 0.2)',
+                borde2: 'rgba(75, 192, 192, 1)',
+                borde2Trans: 'rgba(75, 192, 192, 0.2)',
+                borde3: 'rgba(255, 206, 86, 1)',
+                borde3Trans: 'rgba(255, 206, 86, 0.2)'
+            },
+            oscuro: {
+                ingresos: 'rgba(0, 150, 136, 0.8)',
+                altas: 'rgba(33, 150, 243, 0.8)',
+                traslados: 'rgba(255, 179, 0, 0.8)',
+                policial: 'rgba(156, 39, 176, 0.8)',
+                derivados: 'rgba(244, 67, 54, 0.8)',
+                borde1: 'rgba(33, 150, 243, 1)',
+                borde1Trans: 'rgba(33, 150, 243, 0.3)',
+                borde2: 'rgba(0, 150, 136, 1)',
+                borde2Trans: 'rgba(0, 150, 136, 0.3)',
+                borde3: 'rgba(255, 179, 0, 1)',
+                borde3Trans: 'rgba(255, 179, 0, 0.3)'
+            }
+        };
+
+        let temaActual = 'claro';
+
         // Gráfico Comparativo - Turno 1 (Por Día)
         const datosTurno1 = {
             labels: ["02-12", "05-12", "07-12 20:00-08:00", "09-12", "12-12", "14-12 20:00-08:00", "16-12", "19-12", "21-12 20:00-08:00", "23-12", "25-12 20:00-08:00"],
             datasets: [
-                { label: "Ingresos", data: [60, 53, 30, 69, 53, 31, 59, 63, 31, 79, 37], backgroundColor: "rgba(75, 192, 192, 0.6)" },
-                { label: "Altas AD", data: [19, 14, 0, 12, 1, 0, 3, 3, 0, 5, 1], backgroundColor: "rgba(54, 162, 235, 0.6)" },
-                { label: "Traslados Ambulancia", data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], backgroundColor: "rgba(255, 206, 86, 0.6)" },
-                { label: "Procedimiento Policial", data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], backgroundColor: "rgba(153, 102, 255, 0.6)" },
-                { label: "Derivados al SAR", data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], backgroundColor: "rgba(255, 99, 132, 0.6)" }
+                { label: "Ingresos", data: [60, 53, 30, 69, 53, 31, 59, 63, 31, 79, 37], backgroundColor: paletas[temaActual].ingresos },
+                { label: "Altas AD", data: [19, 14, 0, 12, 1, 0, 3, 3, 0, 5, 1], backgroundColor: paletas[temaActual].altas },
+                { label: "Traslados Ambulancia", data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], backgroundColor: paletas[temaActual].traslados },
+                { label: "Procedimiento Policial", data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], backgroundColor: paletas[temaActual].policial },
+                { label: "Derivados al SAR", data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], backgroundColor: paletas[temaActual].derivados }
             ]
         };
 
@@ -168,11 +260,11 @@
         const datosTurno2 = {
             labels: ["03-12", "06-12", "08-12", "10-12", "13-12", "15-12", "17-12", "20-12", "22-12 (08:00-20:00)", "24-12", "26-12"],
             datasets: [
-                { label: "Ingresos", data: [66, 70, 68, 55, 48, 48, 54, 48, 69, 39, 94], backgroundColor: "rgba(75, 192, 192, 0.6)" },
-                { label: "Altas AD", data: [17, 14, 1, 1, 0, 2, 6, 4, 0, 5, 3], backgroundColor: "rgba(54, 162, 235, 0.6)" },
-                { label: "Traslados Ambulancia", data: [1, 1, 5, 1, 2, 0, 1, 0, 1, 2, 3], backgroundColor: "rgba(255, 206, 86, 0.6)" },
-                { label: "Procedimiento Policial", data: [4, 4, 3, 1, 3, 2, 4, 3, 6, 2, 2], backgroundColor: "rgba(153, 102, 255, 0.6)" },
-                { label: "Derivados al SAR", data: [0, 0, 2, 2, 0, 4, 0, 1, 1, 1, 0], backgroundColor: "rgba(255, 99, 132, 0.6)" }
+                { label: "Ingresos", data: [66, 70, 68, 55, 48, 48, 54, 48, 69, 39, 94], backgroundColor: paletas[temaActual].ingresos },
+                { label: "Altas AD", data: [17, 14, 1, 1, 0, 2, 6, 4, 0, 5, 3], backgroundColor: paletas[temaActual].altas },
+                { label: "Traslados Ambulancia", data: [1, 1, 5, 1, 2, 0, 1, 0, 1, 2, 3], backgroundColor: paletas[temaActual].traslados },
+                { label: "Procedimiento Policial", data: [4, 4, 3, 1, 3, 2, 4, 3, 6, 2, 2], backgroundColor: paletas[temaActual].policial },
+                { label: "Derivados al SAR", data: [0, 0, 2, 2, 0, 4, 0, 1, 1, 1, 0], backgroundColor: paletas[temaActual].derivados }
             ]
         };
 
@@ -187,11 +279,11 @@
         const datosTurno3 = {
             labels: ["04-12", "07-12", "14-12", "15-12", "18-12", "21-12"],
             datasets: [
-                { label: "Ingresos", data: [52, 54, 59, 39, 65, 44], backgroundColor: "rgba(75, 192, 192, 0.6)" },
-                { label: "Altas AD", data: [3, 1, 4, 0, 9, 0], backgroundColor: "rgba(54, 162, 235, 0.6)" },
-                { label: "Traslados Ambulancia", data: [0, 0, 1, 0, 2, 0], backgroundColor: "rgba(255, 206, 86, 0.6)" },
-                { label: "Procedimiento Policial", data: [0, 0, 6, 5, 4, 0], backgroundColor: "rgba(153, 102, 255, 0.6)" },
-                { label: "Derivados al SAR", data: [0, 0, 0, 3, 1, 0], backgroundColor: "rgba(255, 99, 132, 0.6)" }
+                { label: "Ingresos", data: [52, 54, 59, 39, 65, 44], backgroundColor: paletas[temaActual].ingresos },
+                { label: "Altas AD", data: [3, 1, 4, 0, 9, 0], backgroundColor: paletas[temaActual].altas },
+                { label: "Traslados Ambulancia", data: [0, 0, 1, 0, 2, 0], backgroundColor: paletas[temaActual].traslados },
+                { label: "Procedimiento Policial", data: [0, 0, 6, 5, 4, 0], backgroundColor: paletas[temaActual].policial },
+                { label: "Derivados al SAR", data: [0, 0, 0, 3, 1, 0], backgroundColor: paletas[temaActual].derivados }
             ]
         };
 
@@ -228,14 +320,14 @@
         ];
 
         const ctxEstablecimientos = document.getElementById('graficoEstablecimientos').getContext('2d');
-        new Chart(ctxEstablecimientos, {
+        const chartEstablecimientos = new Chart(ctxEstablecimientos, {
             type: 'bar',
             data: {
                 labels: labelsEstablecimientos,
                 datasets: [{
                     label: "Pacientes por Establecimiento",
                     data: dataEstablecimientos,
-                    backgroundColor: "rgba(75, 192, 192, 0.6)"
+                    backgroundColor: paletas[temaActual].ingresos
                 }]
             },
             options: {
@@ -260,22 +352,22 @@
                 {
                     label: "Turno 1",
                     data: [526, 43, 0, 0, 0],
-                    borderColor: "rgba(54, 162, 235, 1)",
-                    backgroundColor: "rgba(54, 162, 235, 0.2)",
+                    borderColor: paletas[temaActual].borde1,
+                    backgroundColor: paletas[temaActual].borde1Trans,
                     fill: true
                 },
                 {
                     label: "Turno 2",
                     data: [678, 49, 14, 30, 11],
-                    borderColor: "rgba(75, 192, 192, 1)",
-                    backgroundColor: "rgba(75, 192, 192, 0.2)",
+                    borderColor: paletas[temaActual].borde2,
+                    backgroundColor: paletas[temaActual].borde2Trans,
                     fill: true
                 },
                 {
                     label: "Turno 3",
                     data: [313, 19, 5, 15, 4],
-                    borderColor: "rgba(255, 206, 86, 1)",
-                    backgroundColor: "rgba(255, 206, 86, 0.2)",
+                    borderColor: paletas[temaActual].borde3,
+                    backgroundColor: paletas[temaActual].borde3Trans,
                     fill: true
                 }
             ]
@@ -285,8 +377,52 @@
         const chartTendencias = new Chart(ctxTendencias, {
             type: 'line',
             data: datosTendencias,
-            options: { responsive: true, scales: { y: { beginAtZero: true } } }
+            options: {
+                responsive: true,
+                scales: {
+                    y: { beginAtZero: true, grid: { display: false } },
+                    x: { grid: { display: false } }
+                }
+            }
         });
+
+        function aplicarTema(tema) {
+            temaActual = tema;
+            document.body.classList.toggle('dark', tema === 'oscuro');
+
+            [datosTurno1, datosTurno2, datosTurno3].forEach(ds => {
+                ds.datasets[0].backgroundColor = paletas[tema].ingresos;
+                ds.datasets[1].backgroundColor = paletas[tema].altas;
+                ds.datasets[2].backgroundColor = paletas[tema].traslados;
+                ds.datasets[3].backgroundColor = paletas[tema].policial;
+                ds.datasets[4].backgroundColor = paletas[tema].derivados;
+            });
+
+            chartEstablecimientos.data.datasets[0].backgroundColor = paletas[tema].ingresos;
+            chartTurno1.update();
+            chartTurno2.update();
+            chartTurno3.update();
+
+            datosTendencias.datasets[0].borderColor = paletas[tema].borde1;
+            datosTendencias.datasets[0].backgroundColor = paletas[tema].borde1Trans;
+            datosTendencias.datasets[1].borderColor = paletas[tema].borde2;
+            datosTendencias.datasets[1].backgroundColor = paletas[tema].borde2Trans;
+            datosTendencias.datasets[2].borderColor = paletas[tema].borde3;
+            datosTendencias.datasets[2].backgroundColor = paletas[tema].borde3Trans;
+            chartEstablecimientos.update();
+            chartTendencias.update();
+        }
+
+        // Controlar la visualización de las tendencias por turno
+        const selectTendencia = document.getElementById('seleccionTendencia');
+        function mostrarTendencia(valor) {
+            chartTendencias.data.datasets.forEach((ds, idx) => {
+                ds.hidden = valor !== 'todos' && valor !== String(idx + 1);
+            });
+            chartTendencias.update();
+        }
+        selectTendencia.addEventListener('change', e => mostrarTendencia(e.target.value));
+        mostrarTendencia(selectTendencia.value);
 
         // Controlar la visualización de los gráficos por turno
         const selectTurno = document.getElementById('seleccionTurno');
@@ -306,6 +442,11 @@
         selectTurno.addEventListener('change', e => mostrarTurno(e.target.value));
         // Mostrar por defecto el primer turno
         mostrarTurno(selectTurno.value);
+
+        // Cambio de tema
+        const selectTema = document.getElementById('selectorTema');
+        selectTema.addEventListener('change', e => aplicarTema(e.target.value));
+        aplicarTema(selectTema.value);
 
         // Manejo del formulario de ingreso de datos
         document.getElementById('formDatos').addEventListener('submit', function(e) {


### PR DESCRIPTION
## Summary
- add dark mode styles and theme dropdown
- update chart colors dynamically via JavaScript
- enable theme switching for all graphs

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a5355b300832297b36d7e184c3f01